### PR TITLE
Implement sock juggling

### DIFF
--- a/server.c
+++ b/server.c
@@ -21,11 +21,9 @@
 #endif
 
 struct connection_descriptor{
-    time_t login_time;
     uint32_t sockfd;
     struct sockaddr_in serv_sockaddr;
     struct sockaddr_in cli_sockaddr;
-    struct user_meta *user_meta;
 };
 
 int serverloop(uint8_t flags){
@@ -79,15 +77,16 @@ int serverloop(uint8_t flags){
             clisock = accept(listensockfd, NULL, NULL);
             if(clisock != -1){
                 errno = 0;
-                struct sockaddr_in metapeeraddr = {0};
-		
+
 		struct connection_descriptor temp = {0};
+
+                struct sockaddr_in metapeeraddr = {0};
 			
 		socklen_t sl = sizeof(temp.cli_sockaddr);
                 if(getpeername(clisock, (struct sockaddr *)&temp.cli_sockaddr, &sl) == -1){
                     perror("getpeername()");
                 }
-                fprintf(stdout, "Got connection from %s\n", inet_ntoa(metapeeraddr.sin_addr));
+                fprintf(stdout, "Got connection from %s\n", inet_ntoa(temp.cli_sockaddr.sin_addr));
 
                 memset(buffer, 0, sizeof(buffer));
                 memcpy(buffer, actmessage, sizeof(actmessage));


### PR DESCRIPTION
Changes to enable the server to handle multiplexing large numbers of clients concurrently.

TODO:
- [ ] Adjust `serverloop()` to fill out a `struct connection_descriptor` with all the relevant information during an `accept()`
  - [ ] Use `getsockname()` to get server side information
  - [ ] Use `getpeername()` to get client side information
- [ ] Adjust `serverloop()` to destroy the relevant `struct connection_descriptor` when the associated `sockfd` has died

NOTES:
I'm not sure how I'll go about implementing the later `poll()` loop; whether or not it should be part of `serverloop()` or if I should split them into two parts running concurrently? ie on separate threads